### PR TITLE
Removed Placeholders and Get Latest Release

### DIFF
--- a/.github/workflows/atmos-release.yaml
+++ b/.github/workflows/atmos-release.yaml
@@ -17,16 +17,23 @@ jobs:
       - "ubuntu-latest"
 
     steps:
+      # TODO replace this placeholder action with the true API call
+      # to get this value from the atmos pro app
+      - name: Get latest release commit SHA
+        id: get_latest_release_sha
+        shell: bash
+        run: |
+          latest_release=$(gh release list --limit 1 --json tagName,commit --jq '.[0]')
+          commit_sha=$(echo "$latest_release" | jq -r '.commit.sha')
+          echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
+
       - name: Gather Affected Stacks
         id: affected
         uses: cloudposse/github-action-atmos-affected-stacks@v3
         with:
           atmos-version: ${{ vars.ATMOS_VERSION }}
           atmos-config-path: ${{ vars.ATMOS_CONFIG_PATH }}
-          # TODO
-          # We need to specify what to include in this release
-          # All changes since the last release?
-          # s.t. base is last release, head is this release
+          base-ref: ${{ steps.get_latest_release_sha.outputs.commit_sha }}
 
       - name: Trigger Atmos Pro
         if: ${{ steps.affected.outputs.has-affected-stacks == 'true' }}

--- a/.github/workflows/atmos-release.yaml
+++ b/.github/workflows/atmos-release.yaml
@@ -23,8 +23,10 @@ jobs:
         id: get_latest_release_sha
         shell: bash
         run: |
-          latest_release=$(gh release list --limit 1 --json tagName,commit --jq '.[0]')
-          commit_sha=$(echo "$latest_release" | jq -r '.commit.sha')
+          echo "Getting last 2 releases. This release and the previous..."
+          latest_release_tag=$(gh release list --limit 2 --json tagName --jq '.[1].tagName')
+          echo "Getting the SHA of the previous release..."
+          commit_sha=$(gh api repos/${{ github.repository }}/git/ref/tags/$latest_release_tag --jq '.object.sha')
           echo "commit_sha=$commit_sha" >> $GITHUB_OUTPUT
 
       - name: Gather Affected Stacks

--- a/.github/workflows/atmos-terraform-apply.yaml
+++ b/.github/workflows/atmos-terraform-apply.yaml
@@ -7,22 +7,18 @@ on:
       component:
         description: "Atmos Component"
         type: string
-        default: "s3-bucket/mock-parent" # TODO used for testing, remove me
       stack:
         description: "Atmos Stack"
         type: string
-        default: "plat-use2-dev" # TODO used for testing, remove me
       sha:
         description: "Commit SHA"
         type: string
       environment:
         description: "GitHub environment"
         type: string
-        default: "nonprod" # TODO used for testing, remove me
       atmos_pro_run_id:
         description: "Atmos Pro Run ID"
         type: string
-        default: "12345" # TODO used for testing, remove me
 
 concurrency:
   group: "${{ inputs.component }}-${{ inputs.stack }}"
@@ -47,8 +43,7 @@ jobs:
         with:
           component: ${{ inputs.component }}
           stack: ${{ inputs.stack }}
-          # sha: ${{ inputs.sha }}
-          sha: ${{ github.sha }} # TODO used for testing, remove me
+          sha: ${{ inputs.sha }}
           atmos-version: ${{ vars.ATMOS_VERSION }}
           atmos-config-path: ${{ vars.ATMOS_CONFIG_PATH }}
 
@@ -59,8 +54,7 @@ jobs:
         with:
           component: ${{ inputs.component }}
           stack: ${{ inputs.stack }}
-          # sha: ${{ inputs.sha }}
-          sha: ${{ github.sha }} # TODO used for testing, remove me
+          sha: ${{ inputs.sha }}
           atmos-version: ${{ vars.ATMOS_VERSION }}
           atmos-config-path: ${{ vars.ATMOS_CONFIG_PATH }}
 
@@ -78,7 +72,6 @@ jobs:
         with:
           component: ${{ inputs.component }}
           stack: ${{ inputs.stack }}
-          # sha: ${{ inputs.sha }}
-          sha: ${{ github.sha }} # TODO used for testing, remove me
+          sha: ${{ inputs.sha }}
           atmos-version: ${{ vars.ATMOS_VERSION }}
           atmos-config-path: ${{ vars.ATMOS_CONFIG_PATH }}

--- a/.github/workflows/atmos-terraform-plan.yaml
+++ b/.github/workflows/atmos-terraform-plan.yaml
@@ -6,18 +6,15 @@ on:
       component:
         description: "Atmos Component"
         type: string
-        default: "s3-bucket/mock-parent" # TODO used for testing, remove me
       stack:
         description: "Atmos Stack"
         type: string
-        default: "plat-use2-dev" # TODO used for testing, remove me
       sha:
         description: "Commit SHA"
         type: string
       atmos_pro_run_id:
         description: "Atmos Pro Run ID"
         type: string
-        default: "12345" # TODO used for testing, remove me
 
 concurrency:
   group: "${{ inputs.component }}-${{ inputs.stack }}"
@@ -38,7 +35,6 @@ jobs:
         with:
           component: ${{ inputs.component }}
           stack: ${{ inputs.stack }}
-          # sha: ${{ inputs.sha }}
-          sha: ${{ github.sha }} # TODO used for testing, remove me
+          sha: ${{ inputs.sha }}
           atmos-version: ${{ vars.ATMOS_VERSION }}
           atmos-config-path: ${{ vars.ATMOS_CONFIG_PATH }}


### PR DESCRIPTION
## what
- Removed test values for dispatch workflows
- Added last release commit sha retrieve in release workflow

## why
- We're now using the demo atmos pro app to trigger these workflows and no longer need placeholders
- A release should gather all affected changes since the last release

## references
- n/a