### PR TITLE
Add atmos-include-dependents flag to release workflow

### DIFF
--- a/.github/workflows/atmos-release.yaml
+++ b/.github/workflows/atmos-release.yaml
@@ -44,6 +44,7 @@ jobs:
           atmos-version: ${{ vars.ATMOS_VERSION }}
           atmos-config-path: ${{ vars.ATMOS_CONFIG_PATH }}
           base-ref: ${{ steps.get_latest_release_sha.outputs.commit_sha }}
+          atmos-include-dependents: true
 
       - name: Trigger Atmos Pro
         if: ${{ steps.affected.outputs.has-affected-stacks == 'true' }}

--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -11,7 +11,7 @@ components:
           - s3-bucket/defaults
         component: s3-bucket
       vars:
-        name: parent6
+        name: parent7
         attributes:
           - mock
 


### PR DESCRIPTION
## what
- atmos-include-dependents flag

## why
- Include deps

## references
- n/a