### PR TITLE
Change GitOps AWS Team Role to `planner`

### DIFF
--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -148,8 +148,8 @@ integrations:
         table: "ex1-core-use2-auto-gitops-plan-storage"
         role: "arn:aws:iam::461333128641:role/ex1-core-use2-auto-gha-iam-gitops"
       role:
-        plan: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-gitops"
-        apply: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-gitops"
+        plan: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planner"
+        apply: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planner"
       matrix:
         sort-by: |-
           .stack_slug


### PR DESCRIPTION
## what
- Use `planner` AWS Team with GitOps

## why
- The `planner` role allows ReadOnly access for CPTEST. We want to use a less permissive role here, especially since this is public. Plus the mock components do not apply anything in AWS anyway

## references
- n/a