### PR TITLE
Use `planners` AWS Team

### DIFF
--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -148,8 +148,8 @@ integrations:
         table: "ex1-core-use2-auto-gitops-plan-storage"
         role: "arn:aws:iam::461333128641:role/ex1-core-use2-auto-gha-iam-gitops"
       role:
-        plan: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planner"
-        apply: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planner"
+        plan: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planners"
+        apply: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planners"
       matrix:
         sort-by: |-
           .stack_slug


### PR DESCRIPTION
## what
- Change `planner` to `planners`

## why
- The role should be `arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planners`. Planners plural

## references
- n/a