### PR TITLE
DEV-3306: Use Cloudformation Backend

### DIFF
--- a/components/docker/infrastructure/Dockerfile
+++ b/components/docker/infrastructure/Dockerfile
@@ -2,7 +2,7 @@
 ARG GEODESIC_VERSION=3.0.0
 ARG GEODESIC_OS=debian
 # https://github.com/cloudposse/atmos
-ARG ATMOS_VERSION=1.84.0
+ARG ATMOS_VERSION=1.182.0
 # This should match the version set in .github/workflows/auto-format.yaml
 ARG TF_1_VERSION=1.5.7
 

--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -144,12 +144,12 @@ integrations:
       infracost-enabled: "False"
       artifact-storage:
         region: "us-east-1"
-        bucket: "atmos-pro-example-advanced-planfiles"
-        table: "atmos-pro-example-advanced-planfiles"
-        role: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
+        bucket: "atmos-pro-ex1-tfplan"
+        table: "atmos-pro-ex1-tfplan"
+        role: "arn:aws:iam::630114703016:role/atmos-pro-ex1-github-actions"
       role:
-        plan: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
-        apply: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
+        plan: "arn:aws:iam::630114703016:role/atmos-pro-ex1-github-actions"
+        apply: "arn:aws:iam::630114703016:role/atmos-pro-ex1-github-actions"
       matrix:
         sort-by: |-
           .stack_slug

--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -157,19 +157,10 @@ integrations:
           .stack_slug | split("-") | [.[0], .[2]] | join("-")
 
 
-# `Go` templates in Atmos manifests
-# https://atmos.tools/core-concepts/stacks/templates
-# https://pkg.go.dev/text/template
 templates:
   settings:
-    enabled: true
-    evaluations: 1
-    # https://masterminds.github.io/sprig
+    enabled: false
     sprig:
-      enabled: true
-    # https://docs.gomplate.ca
+      enabled: false
     gomplate:
-      enabled: true
-      timeout: 5
-      # https://docs.gomplate.ca/datasources
-      datasources: {}
+      enabled: false

--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -144,8 +144,8 @@ integrations:
       infracost-enabled: "False"
       artifact-storage:
         region: "us-east-1"
-        bucket: "atmos-pro-example-advanced-tfstate"
-        table: "atmos-pro-example-advanced-tfstate"
+        bucket: "atmos-pro-example-advanced-planfiles"
+        table: "atmos-pro-example-advanced-planfiles"
         role: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
       role:
         plan: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"

--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -143,10 +143,10 @@ integrations:
       terraform-version: "1.5.7"
       infracost-enabled: "False"
       artifact-storage:
-        region: "us-east-2"
-        bucket: "ex1-core-use2-auto-gitops-plan-storage"
-        table: "ex1-core-use2-auto-gitops-plan-storage"
-        role: "arn:aws:iam::461333128641:role/ex1-core-use2-auto-gha-iam-gitops"
+        region: "us-east-1"
+        bucket: "atmos-pro-example-advanced-tfstate"
+        table: "atmos-pro-example-advanced-tfstate"
+        role: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
       role:
         plan: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
         apply: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"

--- a/rootfs/usr/local/etc/atmos/atmos.yaml
+++ b/rootfs/usr/local/etc/atmos/atmos.yaml
@@ -148,8 +148,8 @@ integrations:
         table: "ex1-core-use2-auto-gitops-plan-storage"
         role: "arn:aws:iam::461333128641:role/ex1-core-use2-auto-gha-iam-gitops"
       role:
-        plan: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planners"
-        apply: "arn:aws:iam::582055374050:role/cptest-core-gbl-identity-planners"
+        plan: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
+        apply: "arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions"
       matrix:
         sort-by: |-
           .stack_slug

--- a/stacks/orgs/ex1/_defaults.yaml
+++ b/stacks/orgs/ex1/_defaults.yaml
@@ -29,7 +29,7 @@ terraform:
     s3:
       bucket: atmos-pro-example-advanced-tfstate
       dynamodb_table: atmos-pro-example-advanced-tfstate
-      role_arn: null
+      role_arn: ""
       # role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
       encrypt: true
       key: terraform.tfstate
@@ -39,7 +39,7 @@ terraform:
     s3:
       # This ensures that remote-state uses the role_arn even when
       # the backend has role_arn overridden to be set to `null`.
-      role_arn: null
+      role_arn: ""
       # role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
 
   settings:

--- a/stacks/orgs/ex1/_defaults.yaml
+++ b/stacks/orgs/ex1/_defaults.yaml
@@ -23,24 +23,19 @@ terraform:
           - environment
           - stage
 
-  # Valid options: s3, remote, vault, etc.
   backend_type: s3
   backend:
     s3:
-      bucket: atmos-pro-example-advanced-tfstate
-      dynamodb_table: atmos-pro-example-advanced-tfstate
+      bucket: atmos-pro-ex1-tfstate
+      dynamodb_table: atmos-pro-ex1-tfstate
       role_arn: ""
-      # role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
       encrypt: true
       key: terraform.tfstate
       acl: bucket-owner-full-control
       region: us-east-1
   remote_state_backend:
     s3:
-      # This ensures that remote-state uses the role_arn even when
-      # the backend has role_arn overridden to be set to `null`.
       role_arn: ""
-      # role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
 
   settings:
     github:

--- a/stacks/orgs/ex1/_defaults.yaml
+++ b/stacks/orgs/ex1/_defaults.yaml
@@ -27,18 +27,18 @@ terraform:
   backend_type: s3
   backend:
     s3:
-      bucket: cptest-core-ue2-root-tfstate-ex1
-      dynamodb_table: cptest-core-ue2-root-tfstate-ex1-lock
-      role_arn: arn:aws:iam::822777368227:role/cptest-core-gbl-root-tfstate-ex1
+      bucket: atmos-pro-example-advanced-tfstate
+      dynamodb_table: atmos-pro-example-advanced-tfstate
+      role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
       encrypt: true
       key: terraform.tfstate
       acl: bucket-owner-full-control
-      region: us-east-2
+      region: us-east-1
   remote_state_backend:
     s3:
       # This ensures that remote-state uses the role_arn even when
       # the backend has role_arn overridden to be set to `null`.
-      role_arn: arn:aws:iam::822777368227:role/cptest-core-gbl-root-tfstate-ex1
+      role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
 
   settings:
     github:

--- a/stacks/orgs/ex1/_defaults.yaml
+++ b/stacks/orgs/ex1/_defaults.yaml
@@ -29,7 +29,8 @@ terraform:
     s3:
       bucket: atmos-pro-example-advanced-tfstate
       dynamodb_table: atmos-pro-example-advanced-tfstate
-      role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
+      role_arn: null
+      # role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
       encrypt: true
       key: terraform.tfstate
       acl: bucket-owner-full-control
@@ -38,7 +39,8 @@ terraform:
     s3:
       # This ensures that remote-state uses the role_arn even when
       # the backend has role_arn overridden to be set to `null`.
-      role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
+      role_arn: null
+      # role_arn: arn:aws:iam::630114703016:role/atmos-pro-example-advanced-github-actions
 
   settings:
     github:

--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -22,4 +22,4 @@ components:
 
     cluster:
       vars:
-        name: cluster2
+        name: cluster3


### PR DESCRIPTION
## what
- Replace backend and roles with resources deployed with Cloudformation

## why
- Use cloudformation to deploy all requirements for Atmos Pro

## references
- DEV-3306
- https://github.com/cloudposse/aws-cloudformation-terraform-backend