### PR TITLE
test: reproduce merged PR SHA mismatch

### DIFF
--- a/stacks/catalog/object-storage.yaml
+++ b/stacks/catalog/object-storage.yaml
@@ -2,4 +2,4 @@ components:
   terraform:
     object-storage:
       vars:
-        name: testing 26
+        name: testing 27


### PR DESCRIPTION
## What
Change object-storage name to trigger affected stacks detection.

## Why
Reproduce the merged PR SHA mismatch bug. The current workflow checks out `head.sha` for merged events, which means `HEAD~1` gives the PR's second-to-last commit instead of the pre-merge state of main. For single-commit PRs this happens to work, but for multi-commit PRs the diff is wrong.

## Test Plan
1. Verify plan works on the open PR
2. Merge the PR
3. Verify the merged event correctly detects affected stacks