### PR TITLE
Add version parameter to cluster for per-environment bumping

### DIFF
--- a/components/terraform/cluster/main.tf
+++ b/components/terraform/cluster/main.tf
@@ -62,6 +62,12 @@ variable "lb_id" {
   default     = ""
 }
 
+variable "version" {
+  description = "Version of the cluster"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
@@ -90,4 +96,8 @@ output "vpc_id" {
 
 output "lb_id" {
   value = var.lb_id
+}
+
+output "version" {
+  value = var.version
 }

--- a/components/terraform/cluster/main.tf
+++ b/components/terraform/cluster/main.tf
@@ -62,7 +62,7 @@ variable "lb_id" {
   default     = ""
 }
 
-variable "version" {
+variable "cluster_version" {
   description = "Version of the cluster"
   type        = string
   default     = "1.0.0"
@@ -98,6 +98,6 @@ output "lb_id" {
   value = var.lb_id
 }
 
-output "version" {
-  value = var.version
+output "cluster_version" {
+  value = var.cluster_version
 }

--- a/stacks/catalog/cluster.yaml
+++ b/stacks/catalog/cluster.yaml
@@ -8,4 +8,4 @@ components:
       vars:
         vpc_id: !terraform.state vpc ".vpc_id // ""mock-vpc-id"""
         lb_id: !terraform.state load-balancer ".lb_id // ""mock-lb-id"""
-        version: "1.0.0"
+        cluster_version: "1.0.0"

--- a/stacks/catalog/cluster.yaml
+++ b/stacks/catalog/cluster.yaml
@@ -8,3 +8,4 @@ components:
       vars:
         vpc_id: !terraform.state vpc ".vpc_id // ""mock-vpc-id"""
         lb_id: !terraform.state load-balancer ".lb_id // ""mock-lb-id"""
+        version: "1.0.0"

--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,6 +24,7 @@ components:
     cluster:
       vars:
         name: cluster25
+        version: "1.1.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.

--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,7 +24,7 @@ components:
     cluster:
       vars:
         name: cluster25
-        version: "1.1.0"
+        cluster_version: "1.1.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.


### PR DESCRIPTION
## what

- Added a `version` input variable and matching output to the `cluster` component (default `1.0.0`).
- Set `version: "1.0.0"` as the catalog default in `stacks/catalog/cluster.yaml`.
- Overrode `version: "1.1.0"` for dev in `stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml`; staging and prod stay on the catalog default.

## why

- Enables progressive rollout of cluster version changes by bumping lower environments first (dev → staging → prod).
- Exercises Atmos Pro's affected-stack detection: the dev override should flag only `plat-use2-dev`'s cluster as affected on future version bumps, while catalog edits propagate to all environments.

## references

- N/A