### PR TITLE
Remove concurrency group from Atmos Terraform Apply workflow

### DIFF
--- a/.github/workflows/atmos-terraform-apply.yaml
+++ b/.github/workflows/atmos-terraform-apply.yaml
@@ -23,12 +23,6 @@ on:
         required: true
         type: string
 
-# Avoid running the same stack in parallel mode (from different workflows)
-# This applied to across workflows to both plan and apply
-concurrency:
-  group: "${{ inputs.stack }}-${{ inputs.component }}"
-  cancel-in-progress: false
-
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout


### PR DESCRIPTION
## what

- Remove the `concurrency` block from `.github/workflows/atmos-terraform-apply.yaml`.

## why

- GitHub's concurrency queue allows at most 1 running + 1 pending job per group. When a third apply is queued, the previously-pending one is canceled with "Canceling since a higher priority waiting request exists" — this happens regardless of `cancel-in-progress: false`.
- Removing the group lets every queued apply run to completion instead of being silently superseded by a newer one.
- Terraform state locking remains as the backstop preventing actual parallel mutation of the same state.

## references

- N/A