### PR TITLE
Bump dev cluster version to 1.2.0 and wire demo triggers everywhere

### DIFF
--- a/.claude/skills/atmos-demo-bump/SKILL.md
+++ b/.claude/skills/atmos-demo-bump/SKILL.md
@@ -1,22 +1,26 @@
 ---
 name: atmos-demo-bump
-description: Use when demoing Atmos Pro / Terraform plan changes on this repo's mock components — either (a) bumping a `<component>_version` in a stack to produce a visible plan diff, or (b) wiring up a new or existing mock component with the version-bump demo pattern (random_id keepers + null_resource triggers). Triggered by requests like "bump the cluster version", "set up the <x> component so I can demo a change", "why does the plan show no infrastructure changes", or "add triggers to component X".
+description: Use when demoing Atmos Pro / Terraform plan changes on this repo's mock components — bumping a `<component>_version` or `name` in a stack to produce a visible plan diff, wiring up a mock component with the version-bump pattern (random_id keepers + null_resource triggers), or replaying a demo via an empty commit. Triggered by requests like "bump the cluster version", "bump the <x> name", plain "bump it", "set up the <x> component so I can demo a change", "why does the plan show no infrastructure changes", or "add triggers to component X".
 ---
 
 # Atmos Demo Bump
 
 This repo is an Atmos Pro example. The Terraform components under `components/terraform/` (except `dynamodb`, which is a real AWS module) are **mocks** — they only manage `random_id` resources. To make a plan *show a real infrastructure change* during a demo, each component exposes a `<component>_version` input variable, and that variable is wired to `random_id.keepers` and a `null_resource.triggers`. Bumping the version in a stack forces recreates, which surfaces as real plan lines (not just output-only diffs).
 
-## Two things this skill covers
+## What this skill covers
 
-1. **Bumping an existing demo** — produce a visible plan change in a specific stack.
-2. **Wiring a component** — add the demo pattern to a new or existing mock component.
+1. **Bumping a version** — produce a visible plan change in a specific stack.
+2. **Bumping a name** — increment the numeric suffix on `name` (e.g. `cluster25` → `cluster26`) to force a new `random_id` and all downstream recreates.
+3. **Just "bump it"** — push another empty commit to replay CI/Atmos Pro on the current state.
+4. **Wiring a component** — add the demo pattern to a new or existing mock component.
 
 ---
 
-## 1. Bumping an existing demo
+## 1. Bumping a version
 
 **Goal:** user asks something like "bump the cluster version in dev" or "demo a change on frontend in staging." You need to produce a Terraform plan that shows real replacements, not just `output values will change`.
+
+**Default bump size:** *minor* (e.g. `1.1.0` → `1.2.0`). Only do a major (`1.x.x` → `2.0.0`) or patch (`1.1.0` → `1.1.1`) bump if the user explicitly asks for it.
 
 ### Steps
 
@@ -38,7 +42,44 @@ This repo is an Atmos Pro example. The Terraform components under `components/te
 
 ---
 
-## 2. Wiring a component with the demo pattern
+## 2. Bumping a name
+
+**Goal:** user says "bump the cluster name" or "bump the vpc name in prod." Increment the trailing integer on the component's `name` var by one. Because `name` is a keeper on `random_id.id`, this also rotates the random suffix — so the plan shows a real replace, same as a version bump.
+
+### Steps
+
+1. Find the stack file (same locations as section 1).
+2. Find the component's `name` value — it will look like `cluster25`, `lb5`, `test-instance-7`, etc.
+3. Parse the trailing integer, add `1`, and write it back with the rest of the string unchanged. Examples:
+   - `cluster25` → `cluster26`
+   - `lb5` → `lb6`
+   - `test-instance-7` → `test-instance-8`
+   - `cluster99` → `cluster100` (digits can grow)
+4. If the name has no trailing integer (e.g. just `cluster`), append `2` — treat the bare name as implicit `1`. Confirm with the user if unsure.
+5. Commit with a message like `Bump dev cluster name to cluster26`.
+
+### Verify
+
+`atmos terraform plan <component> -s <stack>` shows `random_id.id` being replaced (the `name` keeper changed), which cascades to the downstream `cluster_id`/`api_id`/etc. outputs.
+
+---
+
+## 3. Just "bump it"
+
+**Goal:** user says a bare "bump it" or "bump the PR" with no version or name in sight. They want CI / Atmos Pro to re-run on the existing branch without changing content.
+
+### Steps
+
+```bash
+git commit --allow-empty -m "Bump"
+git push
+```
+
+That's it. No file changes. Don't invent a code change just because there's nothing to change.
+
+---
+
+## 4. Wiring a component with the demo pattern
 
 **Goal:** a mock component currently has no `<component>_version` variable, or the variable exists but isn't tied to any resource, so bumps don't show plan changes.
 
@@ -104,6 +145,8 @@ Always use `<component>_version`. Do NOT use bare `version` — Terraform reserv
 
 Before handing back to the user:
 
-- Did the plan show real replacements (not just output-only diffs)?
+- Did the plan show real replacements (not just output-only diffs)? (Doesn't apply for an empty-commit "bump it".)
 - If you added the pattern to a component, did you update the catalog to include `<component>_version` as an explicit default?
 - Did you quote the version value in YAML?
+- For a name bump, did you only change the trailing integer and leave the rest of the string intact?
+- For a version bump without explicit instructions, did you do a minor bump?

--- a/.claude/skills/atmos-demo-bump/SKILL.md
+++ b/.claude/skills/atmos-demo-bump/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: atmos-demo-bump
+description: Use when demoing Atmos Pro / Terraform plan changes on this repo's mock components — either (a) bumping a `<component>_version` in a stack to produce a visible plan diff, or (b) wiring up a new or existing mock component with the version-bump demo pattern (random_id keepers + null_resource triggers). Triggered by requests like "bump the cluster version", "set up the <x> component so I can demo a change", "why does the plan show no infrastructure changes", or "add triggers to component X".
+---
+
+# Atmos Demo Bump
+
+This repo is an Atmos Pro example. The Terraform components under `components/terraform/` (except `dynamodb`, which is a real AWS module) are **mocks** — they only manage `random_id` resources. To make a plan *show a real infrastructure change* during a demo, each component exposes a `<component>_version` input variable, and that variable is wired to `random_id.keepers` and a `null_resource.triggers`. Bumping the version in a stack forces recreates, which surfaces as real plan lines (not just output-only diffs).
+
+## Two things this skill covers
+
+1. **Bumping an existing demo** — produce a visible plan change in a specific stack.
+2. **Wiring a component** — add the demo pattern to a new or existing mock component.
+
+---
+
+## 1. Bumping an existing demo
+
+**Goal:** user asks something like "bump the cluster version in dev" or "demo a change on frontend in staging." You need to produce a Terraform plan that shows real replacements, not just `output values will change`.
+
+### Steps
+
+1. Identify the stack file. Stack files live under `stacks/orgs/<org>/<tenant>/<stage>/<region>/<stack>.yaml`. Example for dev: `stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml`.
+2. Find the component block (e.g. `cluster:` under `components.terraform:`).
+3. Find or add the `<component>_version` var under `vars:` and bump it. **Always quote the value** — Atmos/YAML will otherwise drop trailing zeros. Use semver-looking strings (e.g. `"1.1.0"` → `"2.0.0"`).
+4. If the var doesn't exist in the stack yet, it means the stack is inheriting the catalog default (`stacks/catalog/<component>.yaml`) — add it to the env stack, not the catalog, so only that env is bumped.
+5. Commit with a short imperative message, e.g. `Bump dev cluster version to 2.0.0`.
+
+### Verify
+
+- `atmos describe component <component> -s <stack>` — resolved `vars.<component>_version` matches the new value.
+- `atmos terraform plan <component> -s <stack>` — plan shows `# ... will be replaced` lines for `random_id.id` and/or `null_resource.<component>_version`. If the plan *only* shows `Output values will change. No infrastructure changes.`, the triggers aren't wired — go to section 2 and fix the component first.
+
+### Pitfalls
+
+- Terraform reserves bare names like `version`, `count`, `for_each`. Never name the input variable just `version` — always use the `<component>_version` form (`cluster_version`, `api_version`, etc.). This repo already follows that rule.
+- If you want several envs bumped, set them in each env's stack file. Don't touch the catalog default unless you want every stack that inherits it to move together.
+
+---
+
+## 2. Wiring a component with the demo pattern
+
+**Goal:** a mock component currently has no `<component>_version` variable, or the variable exists but isn't tied to any resource, so bumps don't show plan changes.
+
+### The pattern (reference: `components/terraform/cluster/main.tf`)
+
+Every mock component should have four pieces:
+
+```hcl
+# 1. The input variable — always prefix with the component name
+variable "cluster_version" {
+  description = "Version of the cluster"
+  type        = string
+  default     = "1.0.0"
+}
+
+# 2. random_id with the version in keepers — rotates the random suffix on bump
+resource "random_id" "id" {
+  byte_length = 8
+  keepers = {
+    name            = var.name
+    cluster_version = var.cluster_version
+  }
+}
+
+# 3. null_resource with the version in triggers — gives an unambiguous "replace" line in the plan
+resource "null_resource" "cluster_version" {
+  triggers = {
+    cluster_version = var.cluster_version
+  }
+}
+
+# 4. Output the version so downstream components / dashboards can see it
+output "cluster_version" {
+  value = var.cluster_version
+}
+```
+
+### Steps to wire a component
+
+1. Open `components/terraform/<component>/main.tf`.
+2. Add the `variable "<component>_version"` block (default `"1.0.0"`).
+3. Add `<component>_version = var.<component>_version` to the existing `random_id.id` resource's `keepers` map.
+4. Add a `null_resource.<component>_version` with `triggers.<component>_version = var.<component>_version`.
+5. Add an `output "<component>_version"`.
+6. Check `components/terraform/<component>/providers.tf` exists and declares `provider "random"`. If the file is missing, create it:
+   ```hcl
+   provider "random" {}
+   ```
+   The `null` provider does not need to be configured — Terraform ships `null_resource` implicitly.
+7. Update the catalog default at `stacks/catalog/<component>.yaml` to set `vars.<component>_version: "1.0.0"` so the baseline is explicit.
+
+### Naming rule
+
+Always use `<component>_version`. Do NOT use bare `version` — Terraform reserves it. This rule is consistent across the repo.
+
+### Skip list
+
+- `components/terraform/dynamodb/` — this is a real `cloudposse/dynamodb/aws` module, not a mock. Don't add mock triggers there. Demo changes here by toggling real module inputs (e.g. `billing_mode`).
+
+---
+
+## Quick sanity check before finishing
+
+Before handing back to the user:
+
+- Did the plan show real replacements (not just output-only diffs)?
+- If you added the pattern to a component, did you update the catalog to include `<component>_version` as an explicit default?
+- Did you quote the version value in YAML?

--- a/components/terraform/api/main.tf
+++ b/components/terraform/api/main.tf
@@ -75,10 +75,23 @@ variable "cluster_id" {
   default     = ""
 }
 
+variable "api_version" {
+  description = "Version of the API"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name        = var.name
+    api_version = var.api_version
+  }
+}
+
+resource "null_resource" "api_version" {
+  triggers = {
+    api_version = var.api_version
   }
 }
 
@@ -96,4 +109,8 @@ output "database_id" {
 
 output "cluster_id" {
   value = var.cluster_id
+}
+
+output "api_version" {
+  value = var.api_version
 }

--- a/components/terraform/cache/main.tf
+++ b/components/terraform/cache/main.tf
@@ -50,10 +50,23 @@ variable "label_order" {
     EOT
 }
 
+variable "cache_version" {
+  description = "Version of the cache"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name          = var.name
+    cache_version = var.cache_version
+  }
+}
+
+resource "null_resource" "cache_version" {
+  triggers = {
+    cache_version = var.cache_version
   }
 }
 
@@ -63,4 +76,8 @@ locals {
 
 output "cache_id" {
   value = local.mock_cache_id
+}
+
+output "cache_version" {
+  value = var.cache_version
 }

--- a/components/terraform/cdn/main.tf
+++ b/components/terraform/cdn/main.tf
@@ -62,10 +62,23 @@ variable "frontend_id" {
   default     = ""
 }
 
+variable "cdn_version" {
+  description = "Version of the CDN"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name        = var.name
+    cdn_version = var.cdn_version
+  }
+}
+
+resource "null_resource" "cdn_version" {
+  triggers = {
+    cdn_version = var.cdn_version
   }
 }
 
@@ -83,4 +96,8 @@ output "storage_id" {
 
 output "frontend_id" {
   value = var.frontend_id
+}
+
+output "cdn_version" {
+  value = var.cdn_version
 }

--- a/components/terraform/cluster/main.tf
+++ b/components/terraform/cluster/main.tf
@@ -71,7 +71,14 @@ variable "cluster_version" {
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name            = var.name
+    cluster_version = var.cluster_version
+  }
+}
+
+resource "null_resource" "cluster_version" {
+  triggers = {
+    cluster_version = var.cluster_version
   }
 }
 

--- a/components/terraform/database/main.tf
+++ b/components/terraform/database/main.tf
@@ -56,10 +56,23 @@ variable "vpc_id" {
   default     = ""
 }
 
+variable "database_version" {
+  description = "Version of the database"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name             = var.name
+    database_version = var.database_version
+  }
+}
+
+resource "null_resource" "database_version" {
+  triggers = {
+    database_version = var.database_version
   }
 }
 
@@ -73,4 +86,8 @@ output "database_id" {
 
 output "vpc_id" {
   value = var.vpc_id
+}
+
+output "database_version" {
+  value = var.database_version
 }

--- a/components/terraform/frontend/main.tf
+++ b/components/terraform/frontend/main.tf
@@ -62,10 +62,23 @@ variable "cache_id" {
   default     = ""
 }
 
+variable "frontend_version" {
+  description = "Version of the frontend"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name             = var.name
+    frontend_version = var.frontend_version
+  }
+}
+
+resource "null_resource" "frontend_version" {
+  triggers = {
+    frontend_version = var.frontend_version
   }
 }
 
@@ -83,4 +96,8 @@ output "api_id" {
 
 output "cache_id" {
   value = var.cache_id
+}
+
+output "frontend_version" {
+  value = var.frontend_version
 }

--- a/components/terraform/load-balancer/main.tf
+++ b/components/terraform/load-balancer/main.tf
@@ -56,10 +56,23 @@ variable "vpc_id" {
   default     = ""
 }
 
+variable "lb_version" {
+  description = "Version of the load balancer"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name       = var.name
+    lb_version = var.lb_version
+  }
+}
+
+resource "null_resource" "lb_version" {
+  triggers = {
+    lb_version = var.lb_version
   }
 }
 
@@ -73,4 +86,8 @@ output "lb_id" {
 
 output "vpc_id" {
   value = var.vpc_id
+}
+
+output "lb_version" {
+  value = var.lb_version
 }

--- a/components/terraform/monitoring/main.tf
+++ b/components/terraform/monitoring/main.tf
@@ -74,10 +74,23 @@ variable "frontend_id" {
   default     = ""
 }
 
+variable "monitoring_version" {
+  description = "Version of the monitoring stack"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name               = var.name
+    monitoring_version = var.monitoring_version
+  }
+}
+
+resource "null_resource" "monitoring_version" {
+  triggers = {
+    monitoring_version = var.monitoring_version
   }
 }
 
@@ -103,4 +116,8 @@ output "cluster_id" {
 
 output "frontend_id" {
   value = var.frontend_id
+}
+
+output "monitoring_version" {
+  value = var.monitoring_version
 }

--- a/components/terraform/monitoring/providers.tf
+++ b/components/terraform/monitoring/providers.tf
@@ -1,0 +1,3 @@
+provider "random" {
+  # Configuration options for the provider (if any)
+}

--- a/components/terraform/object-storage/main.tf
+++ b/components/terraform/object-storage/main.tf
@@ -40,10 +40,23 @@ variable "descriptor_formats" {
   description = "Descriptor formats"
 }
 
+variable "storage_version" {
+  description = "Version of the object storage"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name            = var.name
+    storage_version = var.storage_version
+  }
+}
+
+resource "null_resource" "storage_version" {
+  triggers = {
+    storage_version = var.storage_version
   }
 }
 
@@ -53,4 +66,8 @@ locals {
 
 output "storage_id" {
   value = local.mock_storage_id
+}
+
+output "storage_version" {
+  value = var.storage_version
 }

--- a/components/terraform/vpc/main.tf
+++ b/components/terraform/vpc/main.tf
@@ -40,10 +40,23 @@ variable "descriptor_formats" {
   description = "Descriptor formats"
 }
 
+variable "vpc_version" {
+  description = "Version of the VPC"
+  type        = string
+  default     = "1.0.0"
+}
+
 resource "random_id" "id" {
   byte_length = 8
   keepers = {
-    name = var.name
+    name        = var.name
+    vpc_version = var.vpc_version
+  }
+}
+
+resource "null_resource" "vpc_version" {
+  triggers = {
+    vpc_version = var.vpc_version
   }
 }
 
@@ -53,4 +66,8 @@ locals {
 
 output "vpc_id" {
   value = local.mock_vpc_id
+}
+
+output "vpc_version" {
+  value = var.vpc_version
 }

--- a/stacks/catalog/api.yaml
+++ b/stacks/catalog/api.yaml
@@ -8,3 +8,4 @@ components:
       vars:
         database_id: !terraform.state database ".database_id // ""mock-database-id"""
         cluster_id: !terraform.state cluster ".cluster_id // ""mock-cluster-id"""
+        api_version: "1.0.0"

--- a/stacks/catalog/cache.yaml
+++ b/stacks/catalog/cache.yaml
@@ -6,3 +6,4 @@ components:
           - component: vpc
       vars:
         vpc_id: !terraform.state vpc ".vpc_id // ""mock-vpc-id"""
+        cache_version: "1.0.0"

--- a/stacks/catalog/cdn.yaml
+++ b/stacks/catalog/cdn.yaml
@@ -8,3 +8,4 @@ components:
       vars:
         storage_id: !terraform.state object-storage ".storage_id // ""mock-storage-id"""
         frontend_id: !terraform.state frontend ".frontend_id // ""mock-frontend-id"""
+        cdn_version: "1.0.0"

--- a/stacks/catalog/database.yaml
+++ b/stacks/catalog/database.yaml
@@ -6,3 +6,4 @@ components:
           - component: vpc
       vars:
         vpc_id: !terraform.state vpc ".vpc_id // ""mock-vpc-id"""
+        database_version: "1.0.0"

--- a/stacks/catalog/frontend.yaml
+++ b/stacks/catalog/frontend.yaml
@@ -8,3 +8,4 @@ components:
       vars:
         api_id: !terraform.state api ".api_id // ""mock-api-id"""
         cache_id: !terraform.state cache ".cache_id // ""mock-cache-id"""
+        frontend_version: "1.0.0"

--- a/stacks/catalog/load-balancer.yaml
+++ b/stacks/catalog/load-balancer.yaml
@@ -6,3 +6,4 @@ components:
           - component: vpc
       vars:
         vpc_id: !terraform.state vpc ".vpc_id // ""mock-vpc-id"""
+        lb_version: "1.0.0"

--- a/stacks/catalog/monitoring.yaml
+++ b/stacks/catalog/monitoring.yaml
@@ -6,3 +6,4 @@ components:
           - component: cluster
       vars:
         cluster_id: !terraform.state cluster ".cluster_id // ""mock-cluster-id"""
+        monitoring_version: "1.0.0"

--- a/stacks/catalog/object-storage.yaml
+++ b/stacks/catalog/object-storage.yaml
@@ -3,3 +3,4 @@ components:
     object-storage:
       vars:
         name: testing 27
+        storage_version: "1.0.0"

--- a/stacks/catalog/vpc.yaml
+++ b/stacks/catalog/vpc.yaml
@@ -1,4 +1,5 @@
 components:
   terraform:
     vpc:
-      vars: {}
+      vars:
+        vpc_version: "1.0.0"

--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,7 +24,7 @@ components:
     cluster:
       vars:
         name: cluster25
-        cluster_version: "2.0.0"
+        cluster_version: "1.2.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.

--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,7 +24,7 @@ components:
     cluster:
       vars:
         name: cluster25
-        cluster_version: "1.1.0"
+        cluster_version: "2.0.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.


### PR DESCRIPTION
## what

- Bumps `cluster_version` for dev (`plat/ue2`) from `1.1.0` to `1.2.0` (minor).
- Extends every mock component (`api`, `cache`, `cdn`, `database`, `frontend`, `load-balancer`, `monitoring`, `object-storage`, `vpc`) with a `<component>_version` input, tied to `random_id.keepers` and a `null_resource.triggers` so bumps show real plan replacements instead of output-only diffs.
- Adds an `atmos-demo-bump` Claude skill documenting version bumps, name bumps, empty-commit "just bump it" replays, and how to wire new components.

## why

- Minor bump keeps the catalog default (`1.0.0`) as the baseline for other stages and lets dev move independently via the pattern introduced in #152.
- The version/keeper/trigger pattern makes the other 9 mock components demoable the same way `cluster` already is — so future demos aren't limited to the cluster component.
- The skill captures the repeatable demo workflow so any future Claude session can execute it consistently.

## references

- Follow-up to #152 (per-environment `cluster_version`).