### PR TITLE
Remove concurrency groups from remaining workflows

### DIFF
--- a/.github/workflows/atmos-pro.yaml
+++ b/.github/workflows/atmos-pro.yaml
@@ -16,12 +16,6 @@ on:
     branches:
       - main
 
-# Avoid conflicting workflow triggers.
-# For example, wait to trigger apply until plan has been triggered
-concurrency:
-  group: "${{ github.ref }}"
-  cancel-in-progress: false
-
 permissions:
   id-token: write # This is required for requesting the JWT (OIDC) token
   contents: read # This is required for actions/checkout

--- a/.github/workflows/atmos-release.yaml
+++ b/.github/workflows/atmos-release.yaml
@@ -5,10 +5,6 @@ on:
     types:
       - published
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   id-token: write # This is required for requesting the JWT (OIDC) token
   contents: read # required to get the previous release SHA

--- a/.github/workflows/atmos-terraform-plan.yaml
+++ b/.github/workflows/atmos-terraform-plan.yaml
@@ -24,13 +24,6 @@ on:
         required: false
         default: "false"
 
-# Avoid running the same stack in parallel mode (from different workflows)
-# This applied to across workflows to both plan and apply
-concurrency:
-  group: "${{ inputs.stack }}-${{ inputs.component }}"
-  # Cancel stale plans so the most recent commit's plan always runs
-  cancel-in-progress: true
-
 permissions:
   id-token: write # This is required for requesting the JWT (OIDC) token
   contents: read # This is required for actions/checkout

--- a/.github/workflows/atmos-upload-instances.yaml
+++ b/.github/workflows/atmos-upload-instances.yaml
@@ -9,12 +9,6 @@ on:
     - cron: '0 0 * * *'
   workflow_dispatch:
 
-# Avoid running the same stack in parallel mode (from different workflows)
-# This applied to across workflows to both plan and apply
-concurrency:
-  group: ${{ github.workflow }}
-  cancel-in-progress: false
-
 permissions:
   id-token: write # This is required for requesting the JWT
   contents: read  # This is required for actions/checkout

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,11 +10,6 @@ on:
     branches:
       - main
 
-# Concurrency ensures only the latest push for this PR will run at a time
-concurrency:
-  group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
-  cancel-in-progress: true
-
 jobs:
   codeowners:
     name: "codeowners"


### PR DESCRIPTION
## what

- Removes the `concurrency:` block from `atmos-terraform-plan.yaml`, `atmos-pro.yaml`, `atmos-upload-instances.yaml`, `atmos-release.yaml`, and `validate.yml`.
- No other keys (permissions, triggers, jobs) are touched.

## why

- Follow-up to #153, which removed the concurrency block from `atmos-terraform-apply.yaml` because GitHub's concurrency queue only allows 1 running + 1 pending run per group, silently dropping superseded runs even with `cancel-in-progress: false`.
- Extends that rationale to the remaining workflows so behavior is consistent across the Atmos Pro suite. Terraform state locking remains the backstop for plan/apply correctness; release and validate will no longer auto-cancel stale runs on rapid pushes, which is an acceptable tradeoff for predictable execution.

## references

- Follow-up to #153