### PR TITLE
Bump cluster name/version in dev and prod for demo

### DIFF
--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -23,8 +23,8 @@ components:
 
     cluster:
       vars:
-        name: cluster42
-        cluster_version: "1.2.0"
+        name: cluster43
+        cluster_version: "1.3.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.

--- a/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
@@ -14,3 +14,10 @@ import:
   - catalog/frontend
   - catalog/cdn
   - catalog/monitoring
+
+components:
+  terraform:
+    cluster:
+      vars:
+        name: cluster-prod1
+        cluster_version: "1.1.0"


### PR DESCRIPTION
## what

- Bump the dev `cluster` component to `cluster43` / `cluster_version: 1.3.0` (usual sequential demo bump).
- Add a first-time `cluster` name/version override on the prod stack (`cluster-prod1` / `cluster_version: 1.1.0`), which previously had none and relied on catalog/component defaults.

## why

- Demo Atmos Pro's plan diff on a version bump (existing `random_id`/`null_resource` triggers already recreate resources on `name`/`cluster_version` change).
- Exercise the Atmos Pro **apply approval gate** end-to-end: `plat-prod` is the only GitHub Environment currently configured with required reviewers (team `engineering`), so bumping prod's cluster is what actually triggers a pending-review apply after merge — dev/staging have no reviewer requirement.

## references

- Continues the pattern from #155, #164, #165.