### PR TITLE
Bump cluster version in dev and prod for demo

### DIFF
--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,7 +24,7 @@ components:
     cluster:
       vars:
         name: cluster43
-        cluster_version: "1.3.0"
+        cluster_version: "1.4.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.

--- a/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
@@ -20,4 +20,4 @@ components:
     cluster:
       vars:
         name: cluster-prod1
-        cluster_version: "1.1.0"
+        cluster_version: "1.2.0"


### PR DESCRIPTION
## what

- Bumps `cluster_version` for the mock `cluster` component in the dev stack from `1.3.0` to `1.4.0`.
- Bumps `cluster_version` for the mock `cluster` component in the prod stack from `1.1.0` to `1.2.0`.

## why

- The version is wired into `random_id.keepers` and `null_resource.triggers` on the mock cluster component, so bumping it forces a real replace and produces a visible Terraform plan diff.
- Needed to demo an Atmos Pro plan/apply change in both dev and prod.

## references

- N/A