### PR TITLE
Bump demo cluster versions

### DIFF
--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,7 +24,7 @@ components:
     cluster:
       vars:
         name: cluster43
-        cluster_version: "1.4.0"
+        cluster_version: "1.4.1"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.

--- a/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
@@ -20,4 +20,4 @@ components:
     cluster:
       vars:
         name: cluster-prod1
-        cluster_version: "1.2.0"
+        cluster_version: "1.4.1"


### PR DESCRIPTION
## what

- Set the dev and production us-east-2 demo cluster versions to 1.4.1.

## why

- Keep both environments aligned for the upcoming demo.

## references

- None.