### PR TITLE
Bump cluster version in dev and prod for demo

### DIFF
--- a/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/dev/us-east-2/demo.yaml
@@ -24,7 +24,7 @@ components:
     cluster:
       vars:
         name: cluster43
-        cluster_version: "1.4.0"
+        cluster_version: "1.5.0"
 
     # This is used to test Atmos Pro with a slash in the name.
     # Delete me after validation.

--- a/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
+++ b/stacks/orgs/ex1/plat/prod/us-east-2/demo.yaml
@@ -20,4 +20,4 @@ components:
     cluster:
       vars:
         name: cluster-prod1
-        cluster_version: "1.2.0"
+        cluster_version: "1.3.0"


### PR DESCRIPTION
## what

- Bump the `cluster_version` var for the `cluster` component in the dev stack from `1.4.0` to `1.5.0`.
- Bump the `cluster_version` var for the `cluster` component in the prod stack from `1.2.0` to `1.3.0`.

## why

- The mock `cluster` component ties `cluster_version` to `random_id` keepers and `null_resource` triggers, so bumping it produces a real, visible Terraform plan diff for demo purposes.

## references

- N/A